### PR TITLE
Publish Releases from GHA

### DIFF
--- a/.github/workflows/publish-container.yml
+++ b/.github/workflows/publish-container.yml
@@ -1,0 +1,55 @@
+name: Create and publish a Docker image
+
+on:
+  push:
+    tags:
+        - 'v*.*.*'
+    branches: ['main']
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: drone-xmpp-test
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for image registry
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/xmpp-interop-testing/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: ${{ env.REGISTRY }}/xmpp-interop-testing/${{ env.IMAGE_NAME}}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true
+

--- a/.harness/orgs/default/projects/default_project/pipelines/xmppinteroptestsdroneplugin.yaml
+++ b/.harness/orgs/default/projects/default_project/pipelines/xmppinteroptestsdroneplugin.yaml
@@ -48,7 +48,7 @@ pipeline:
                   identifier: Build_and_push_to_GHCR
                   spec:
                     connectorRef: GitHub_Container_Registry
-                    repo: ghcr.io/xmpp-interop-testing/sintse-drone
+                    repo: ghcr.io/xmpp-interop-testing/drone-xmpp-test
                     tags:
                       - internal-ci
               - step:
@@ -58,7 +58,7 @@ pipeline:
                   description: Executes the Drone Plugin against the XMPP server that has been created earlier in this Pipeline
                   spec:
                     connectorRef: GitHub_Container_Registry
-                    image: ghcr.io/xmpp-interop-testing/sintse-drone:internal-ci
+                    image: ghcr.io/xmpp-interop-testing/drone-xmpp-test:internal-ci
                     reports:
                       type: JUnit
                       spec:


### PR DESCRIPTION
Also renames container to `drone-xmpp-test` for nicer "branding"