### PR TITLE
Add config option for fail-on-impossible-test

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ The plugin can be configured using the following settings:
 - `disabledSpecifications`: _(optional)_ A comma-separated list of specifications (not case-sensitive) that are to be skipped. For example: `XEP-0045,XEP-0060`
 - `enabledTests`: _(optional)_ A comma-separated list of tests that are the only ones to be run. For example: `EntityCapsTest,SoftwareInfoIntegrationTest`
 - `enabledSpecifications`: _(optional)_ A comma-separated list of specifications (not case-sensitive) that are the only ones to be run. For example: `XEP-0045,XEP-0060`
+- `failOnImpossibleTest`: _(optional)_ If set to 'true', fails the test run if any configured tests were impossible to execute. (default: 'false')
 - `logDir`: _(optional)_ The directory in which the test output and logs are to be stored. This directory will be created, if it does not already exist. Default value: `./output`
 
 ### Provisioning Test Accounts

--- a/drone.sh
+++ b/drone.sh
@@ -64,6 +64,10 @@ if [ "$PLUGIN_ENABLEDSPECIFICATIONS" != "" ]; then
     ENTRYCMD+=("--enabledSpecifications=$PLUGIN_ENABLEDSPECIFICATIONS")
 fi
 
+if [ "$PLUGIN_FAILONIMPOSSIBLETEST" != "" ]; then
+    ENTRYCMD+=("--failOnImpossibleTest=$PLUGIN_FAILONIMPOSSIBLETEST")
+fi
+
 echo "Running: ${ENTRYCMD[*]}"
 
 "${ENTRYCMD[@]}"


### PR DESCRIPTION
Test may be impossible to run, for example, because the server that's being tested does not support a particular feature.

It is not unreasonable for users to assume that, upon a successful test execution result, all tests have passed. In the case of 'impossible' tests, this isn't necessarily the case: some test might not have executed at all.

Especially in scenarios where users have configured the test run to enable a specific subset of the tests (through configuration such as enabledTests and enabledSpecifications) it may be desirable to hard fail when a test was impossible to execute. This enforces that a test run was strictly successful in all tests it was configured to execute.

fixes #10