### PR TITLE
Update sint-server-extensions version to v1.7.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG SINTSE_VERSION="main"
+ARG SINTSE_VERSION="v1.7.0"
 
 FROM ghcr.io/xmpp-interop-testing/xmpp_interop_tests:${SINTSE_VERSION}
 


### PR DESCRIPTION
This changes the Docker container reference from `Main` to a specific version. That should lead to more consistent test results. As a drawback, it forces people to manually upgrade their pipeline configuration when we provide new versions to benefit from new tests. I believe that's in line with other runners.